### PR TITLE
Added 5GB and 10GB swap options

### DIFF
--- a/amtm_modules/swap.mod
+++ b/amtm_modules/swap.mod
@@ -133,14 +133,18 @@ manage_swap(){
 							1)		p_e_l
 									echo " Select a Swap file size"
 									echo
-									echo " 1.  1 GB"
-									echo " 2.  2 GB (recommended)"
+									echo "  1.   1 GB"
+									echo "  2.   2 GB (recommended)"
+									echo "  5.   5 GB"
+									echo " 10.  10 GB"
 
 									while true; do
 										printf "\\n Enter size [1-2 e=Exit] ";read -r size
 										case "$size" in
-											1)	swsize=1048576;break;;
-											2)	swsize=2097152;break;;
+											1)	swsize=1048576; break;;
+											2)	swsize=2097152; break;;
+											5)	swsize=5242880; break;;
+											10)	swsize=10485760;break;;
 										[Ee])	show_amtm menu;break;;
 											*)	printf "\\n input is not an option\\n";;
 										esac

--- a/amtm_modules/swap.mod
+++ b/amtm_modules/swap.mod
@@ -139,7 +139,7 @@ manage_swap(){
 									echo " 10.  10 GB"
 
 									while true; do
-										printf "\\n Enter size [1-2 e=Exit] ";read -r size
+										printf "\\n Enter size [1, 2, 5, 10 e=Exit] ";read -r size
 										case "$size" in
 											1)	swsize=1048576; break;;
 											2)	swsize=2097152; break;;


### PR DESCRIPTION
Added 5GB and 10GB swap size options. Useful when router performs any task with memory work peaks (Eg: Unbound rebuilding database with many zones).