### PR TITLE
Add VPNMON-R3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ amtm
 | Vnstat | dev_null | [Link](https://www.snbforums.com/threads/beta-2-vnstat-on-merlin-ui-cli-and-email-data-use-monitoring-with-full-install-and-menu.70727/) |
 | WireGuard Session Manager | Martineau | [Link](https://www.snbforums.com/forums/asuswrt-merlin-addons.60/?prefix_id=32&starter_id=13215) |
 | Asuswrt-Merlin-AdGuardHome-Installer | SomeWhereOverTheRainBow | [Link](https://www.snbforums.com/threads/new-release-asuswrt-merlin-adguardhome-installer.76506/) |
-| VPNMON-R2 | Viktor Jaep | [Link](https://www.snbforums.com/forums/asuswrt-merlin-addons.60/?prefix_id=36) |
+| VPNMON | Viktor Jaep | [Link](https://www.snbforums.com/forums/asuswrt-merlin-addons.60/?prefix_id=36) |
 | RTRMON | Viktor Jaep | [Link](https://www.snbforums.com/forums/asuswrt-merlin-addons.60/) |
 | WICENS | Maverickcdn | [Link](https://www.snbforums.com/threads/wicens-wan-ip-change-email-notification-script.69294/) |
 | KILLMON | Viktor Jaep | [Link](https://www.snbforums.com/threads/killmon-v1-05-feb-20-2023-ip4-ip6-vpn-kill-switch-monitor-configurator.81758/) |

--- a/amtm
+++ b/amtm
@@ -197,6 +197,7 @@ show_amtm(){
 	spacer
 	/jffs/scripts/dn-vnstat Vnstat vn vnStat¦-¦Data¦use¦monitoring
 	/jffs/scripts/vpnmon-r2.sh vpnmon vp VPNMON-R2¦-¦Monitor¦health¦of¦VPN
+	/jffs/scripts/vpnmon-r3.sh vpnmon_r3 v3 VPNMON-R3¦-¦Monitor¦health¦of¦VPN
 	/jffs/scripts/killmon.sh killmon km KILLMON¦-¦VPN¦kill¦switch¦monitor¦&¦configurator
 	/jffs/scripts/rtrmon.sh rtrmon rt RTRMON¦-¦Monitor¦your¦Routers¦Health
 	/jffs/scripts/backupmon.sh backupmon bm BACKUPMON¦-¦Backup¦and¦restore¦your¦Router
@@ -325,6 +326,7 @@ show_amtm(){
 					j7)		case_j7(){ g_m YazDHCP.mod include;[ "$dlok" = 1 ] && install_YazDHCP || show_amtm menu;};;
 					vn)		case_vn(){ c_e Vnstat;g_m Vnstat.mod include;[ "$dlok" = 1 ] && install_Vnstat || show_amtm menu;};;
 					vp)		case_vp(){ c_e VPNMON-R2;g_m vpnmon.mod include;[ "$dlok" = 1 ] && install_vpnmon || show_amtm menu;};;
+					v3)		case_v3(){ c_e VPNMON-R3;g_m vpnmon_r3.mod include;[ "$dlok" = 1 ] && install_vpnmon_r3 || show_amtm menu;};;
 					km)		case_km(){ c_e KILLMON;g_m killmon.mod include;[ "$dlok" = 1 ] && install_killmon || show_amtm menu;};;
 					rt)		case_rt(){ c_e RTRMON;g_m rtrmon.mod include;[ "$dlok" = 1 ] && install_rtrmon || show_amtm menu;};;
 					bm)		case_bm(){ g_m backupmon.mod include;[ "$dlok" = 1 ] && install_backupmon || show_amtm menu;};;
@@ -520,6 +522,7 @@ show_amtm(){
 			[Jj]7)				case_j7;break;;
 			[Vv][Nn])			case_vn;break;;
 			[Vv][Pp])			case_vp;break;;
+			[Vv]3)				case_v3;break;;
 			[Kk][Mm])			case_km;break;;
 			[Rr][Tt])			case_rt;break;;
 			[Bb][Mm])			case_bm;break;;

--- a/amtm_modules/amtm.mod
+++ b/amtm_modules/amtm.mod
@@ -197,6 +197,7 @@ show_amtm(){
 	spacer
 	/jffs/scripts/dn-vnstat Vnstat vn vnStat¦-¦Data¦use¦monitoring
 	/jffs/scripts/vpnmon-r2.sh vpnmon vp VPNMON-R2¦-¦Monitor¦health¦of¦VPN
+	/jffs/scripts/vpnmon-r3.sh vpnmon_r3 v3 VPNMON-R3¦-¦Monitor¦health¦of¦VPN
 	/jffs/scripts/killmon.sh killmon km KILLMON¦-¦VPN¦kill¦switch¦monitor¦&¦configurator
 	/jffs/scripts/rtrmon.sh rtrmon rt RTRMON¦-¦Monitor¦your¦Routers¦Health
 	/jffs/scripts/backupmon.sh backupmon bm BACKUPMON¦-¦Backup¦and¦restore¦your¦Router
@@ -324,6 +325,7 @@ show_amtm(){
 					j7)		case_j7(){ g_m YazDHCP.mod include;[ "$dlok" = 1 ] && install_YazDHCP || show_amtm menu;};;
 					vn)		case_vn(){ c_e Vnstat;g_m Vnstat.mod include;[ "$dlok" = 1 ] && install_Vnstat || show_amtm menu;};;
 					vp)		case_vp(){ c_e VPNMON-R2;g_m vpnmon.mod include;[ "$dlok" = 1 ] && install_vpnmon || show_amtm menu;};;
+					v3)		case_v3(){ c_e VPNMON-R3;g_m vpnmon_r3.mod include;[ "$dlok" = 1 ] && install_vpnmon_r3 || show_amtm menu;};;
 					km)		case_km(){ c_e KILLMON;g_m killmon.mod include;[ "$dlok" = 1 ] && install_killmon || show_amtm menu;};;
 					rt)		case_rt(){ c_e RTRMON;g_m rtrmon.mod include;[ "$dlok" = 1 ] && install_rtrmon || show_amtm menu;};;
 					bm)		case_bm(){ g_m backupmon.mod include;[ "$dlok" = 1 ] && install_backupmon || show_amtm menu;};;
@@ -519,6 +521,7 @@ show_amtm(){
 			[Jj]7)				case_j7;break;;
 			[Vv][Nn])			case_vn;break;;
 			[Vv][Pp])			case_vp;break;;
+			[Vv]3)  			case_v3;break;;
 			[Kk][Mm])			case_km;break;;
 			[Rr][Tt])			case_rt;break;;
 			[Bb][Mm])			case_bm;break;;

--- a/amtm_modules/vpnmon_r3.mod
+++ b/amtm_modules/vpnmon_r3.mod
@@ -1,0 +1,52 @@
+#!/bin/sh
+#bof
+vpnmon_r3_installed(){
+	scriptname='VPNMON-R3'
+	localVother="$(grep ^version "$scriptloc" | awk '{print $1}' | sed -e 's/version=//;s/"//g')"
+	if [ "$su" = 1 ]; then
+		remoteurl=https://raw.githubusercontent.com/ViktorJp/VPNMON-R3/main/vpnmon-r3.sh
+		remoteVother="$(c_url "$remoteurl" | grep ^version | awk '{print $1}' | sed -e 's/version=//;s/"//g')"
+		grepcheck=ViktorJp
+	fi
+	script_check
+	if [ -z "$su" -a -z "$tpu" ] && [ "$vpnmon_r3Upate" ]; then
+		localver="$lvtpu"
+		upd="${E_BG}$vpnmon_r3Upate{NC}"
+		if [ "$vpnmon_r3MD5" != "$(md5sum "$scriptloc" | awk '{print $1}')" ]; then
+			sed -i '/^vpnmon_r3.*/d' "${add}"/availUpd.txt
+			upd="${E_BG}${NC}$lvtpu"
+			unset localver $vpnmon_r3Upate vpnmon_r3MD5
+		fi
+	fi
+	[ -z "$updcheck" ] && printf "${GN_BG} v3${NC} %-9s%-21s%${COR}s\\n" "open" "VPNMON-R3 $localver" " $upd"
+	case_v3(){
+		trap trap_ctrl 2
+		trap_ctrl(){
+			sleep 2
+			echo "${NC}"
+			exec "$0"
+		}
+		/jffs/scripts/vpnmon-r3.sh -setup
+		trap - 2
+		sleep 2
+		show_amtm menu
+	}
+}
+install_vpnmon_r3(){
+	p_e_l
+	echo " This installs VPNMON-R3 - Monitor the health of your VPN connection"
+	echo " on your router."
+	echo
+	echo " Author: Viktor Jaep"
+	echo " https://www.snbforums.com/forums/asuswrt-merlin-addons.60/?prefix_id=36"
+	c_d
+
+	c_url https://raw.githubusercontent.com/ViktorJp/VPNMON-R3/main/vpnmon-r3.sh -o /jffs/scripts/vpnmon-r3.sh && chmod 755 /jffs/scripts/vpnmon-r3.sh && /jffs/scripts/vpnmon-r3.sh -setup
+	sleep 2
+	if [ -f /jffs/scripts/vpnmon-r3.sh ]; then
+		show_amtm " VPNMON-R3 installed"
+	else
+		am=;show_amtm " VPNMON-R3 installation failed"
+	fi
+}
+#eof


### PR DESCRIPTION
Previously I installed & used VPNMON-R2 via amtm but got an update with R3 recently and bc of that VPNMON vanished from amtm's list. R3 is a standalone tool: different repo, versioning, script filename etc so I added VPNMON-R3 to the module list as a new option alongside R2 (it can be kept on the module list for the time being, R2 worked well for a single VPN client, R3 recommended for multiple).
