### PR TITLE
change entware mirror from bfsu to mirrorz

### DIFF
--- a/amtm
+++ b/amtm
@@ -136,6 +136,7 @@ show_amtm(){
 				localhost.localdomain
 				maurerr.github.io
 				mirrors.bfsu.edu.cn
+				mirrors.cernet.edu.cn
 				oisd.nl
 				onedrive.live.com
 				openstreetmap.org

--- a/amtm_modules/amtm.mod
+++ b/amtm_modules/amtm.mod
@@ -164,6 +164,7 @@ show_amtm(){
 				localhost.localdomain
 				maurerr.github.io
 				mirrors.bfsu.edu.cn
+				mirrors.cernet.edu.cn
 				oisd.nl
 				onedrive.live.com
 				openstreetmap.org

--- a/amtm_modules/entware.mod
+++ b/amtm_modules/entware.mod
@@ -55,10 +55,10 @@ entware_installed(){
 						echo 'ailed to' >/tmp/amtm-entware-check
 					fi
 				fi
-				server=mirrors.bfsu.edu.cn
+				server=mirrors.cernet.edu.cn
 				if [ "$ENTDOMAIN" != "$server" ] && [ -z "$serverOK" ]; then
 					if  ping -c2 -W3 $server &> /dev/null; then
-						printf "- Using Entware server ${GN}$server${NC},\\n  Mirror by Beijing Foreign Studies University\\n"
+						printf "- Using Entware server ${GN}$server${NC},\\n  Mirrors by CERNET\\n"
 						change_opkg_server $server
 						opkg_update
 						[ -s /tmp/amtm-entware-check ] && grep -q 'pdated list' /tmp/amtm-entware-check && serverOK=1
@@ -340,13 +340,13 @@ entware_installed(){
 							else
 								echo "    ${R}$server${NC} failed, mirror by thelonelycoder"
 							fi
-							server=mirrors.bfsu.edu.cn
+							server=mirrors.cernet.edu.cn
 							if ping -c2 -W3 $server &> /dev/null; then
 								es=$((es+1))
-								echo " ${es}. ${GN}$server${NC} - Mirror by Beijing Foreign Studies University"
+								echo " ${es}. ${GN}$server${NC} - Mirrors by CERNET"
 								eval servers$es="$server/entware"
 							else
-								echo "    ${R}$server${NC} failed, mirror by Beijing Foreign Studies University"
+								echo "    ${R}$server${NC} failed, mirrors by CERNET"
 							fi
 
 							selectServer() {

--- a/amtm_modules/entware_setup.mod
+++ b/amtm_modules/entware_setup.mod
@@ -267,19 +267,19 @@ setup_Entware(){
 		else
 			echo "    ${R}$server${NC} failed, mirror by thelonelycoder"
 		fi
-		server=mirrors.bfsu.edu.cn
+		server=mirrors.cernet.edu.cn
 		if ping -c2 -W3 $server &> /dev/null; then
 			c_url https://$server/$(echo $INST_URL | cut -d/ -f1)/Packages.gz -o /tmp/Packages.gz
 			if [ -s /tmp/Packages.gz ]; then
 				es=$((es+1))
-				echo " ${es}. ${GN}$server${NC} - Mirror by Beijing Foreign Studies University"
+				echo " ${es}. ${GN}$server${NC} - Mirrors by CERNET"
 				eval servers$es="$server"
 			else
-				echo "    ${R}$server${NC} failed, mirror by Beijing Foreign Studies University"
+				echo "    ${R}$server${NC} failed, mirrors by CERNET"
 			fi
 			rm -f /tmp/Packages.gz
 		else
-			echo "    ${R}$server${NC} failed, mirror by Beijing Foreign Studies University"
+			echo "    ${R}$server${NC} failed, mirrors by CERNET"
 		fi
 
 		selectServer() {


### PR DESCRIPTION
Here is a CERNET site https://mirrors.cernet.edu.cn (hereinafter referred to as The Site) that provides index and redirect service for CERNET's mirror servers.

As far, There are 3 mirrors for entware on the CERNET: BFSU, CQUPT and NJU.

The Site has been supported by CERNIC, which is the administrative authorit of CERNET, and BFSU's mirror site is one of the part of CERNET. It will redirect the request to satisfied mirror site based on Geo-IP Net's database.

I believe that this change could improve the user's experience in China but far away from Beijing, and balance the stress between CERNET's mirror sites. It can also better cope with the growth or reduction of mirror sites in CERNET in the future.

I‘m not sure about how to deal with the domain whitelist. To delete BFSU seems not a good idea.