### PR TITLE
New "install" parameter for MerlinAU

### DIFF
--- a/amtm_modules/MerlinAU.mod
+++ b/amtm_modules/MerlinAU.mod
@@ -37,7 +37,7 @@ install_MerlinAU(){
 	printf " Major contributor: Martinski\\n"
 	c_d
 	clear
-	c_url https://raw.githubusercontent.com/ExtremeFiretop/MerlinAutoUpdate-Router/main/MerlinAU.sh -o /jffs/scripts/MerlinAU.sh && chmod 0755 /jffs/scripts/MerlinAU.sh && /jffs/scripts/MerlinAU.sh
+	c_url https://raw.githubusercontent.com/ExtremeFiretop/MerlinAutoUpdate-Router/main/MerlinAU.sh -o /jffs/scripts/MerlinAU.sh && chmod 0755 /jffs/scripts/MerlinAU.sh && /jffs/scripts/MerlinAU.sh install
 	sleep 2
 	if [ -f /jffs/scripts/MerlinAU.sh ]; then
 		show_amtm " MerlinAU installed"


### PR DESCRIPTION
Added new "**install**" parameter, which is needed to perform a full installation of the latest **1.4.0** release version.