### PR TITLE
feat(entware): :zap: improve mount logic and cleanup for /tmp/opt

### DIFF
--- a/amtm_modules/mount-entware.mod
+++ b/amtm_modules/mount-entware.mod
@@ -1,33 +1,39 @@
 #!/bin/sh
 #bof
 
-mount_entware(){
-	if [ -f "${opkgFile%/opkg}/diversion" ]; then
-		logger -t Entware "Starting Entware and Diversion services on $1"
-		ln -nsf "${opkgFile%/bin/opkg}" /tmp/opt
-		/opt/etc/init.d/rc.unslung start $0
-		service restart_dnsmasq
-	else
-		logger -t Entware "Starting Entware services on $1"
-		ln -nsf "${opkgFile%/bin/opkg}" /tmp/opt
-		/opt/etc/init.d/rc.unslung start $0
-	fi
+MOUNT_PATH="${1:-/mnt/MERLIN}"
+
+mount_entware() {
+    # Clean up /tmp/opt if it's a directory or broken link
+    [ ! -L /tmp/opt ] && rm -rf /tmp/opt
+
+    if [ -f "${opkgFile%/opkg}/diversion" ]; then
+        logger -t Entware "Starting Entware and Diversion services on $MOUNT_PATH"
+        ln -nsf "${opkgFile%/bin/opkg}" /tmp/opt
+        /opt/etc/init.d/rc.unslung start "$0"
+        service restart_dnsmasq
+    else
+        logger -t Entware "Starting Entware services on $MOUNT_PATH"
+        ln -nsf "${opkgFile%/bin/opkg}" /tmp/opt
+        /opt/etc/init.d/rc.unslung start "$0"
+    fi
 }
 
-opkgFile=$(/usr/bin/find $1/entware/bin/opkg 2> /dev/null)
+opkgFile=$(/usr/bin/find "$MOUNT_PATH/entware/bin/opkg" 2> /dev/null)
+
 if [ "$opkgFile" ] && [ ! -d /opt/bin ]; then
-	mount_entware $1
+    mount_entware
 elif [ "$opkgFile" ] && [ -d /opt/bin ]; then
-	logger -t Entware "Not starting Entware services on $1, Entware is already started"
+    logger -t Entware "Not starting Entware services on $MOUNT_PATH, Entware is already started"
 else
-	opkgUnknown=$(/usr/bin/find $1/entware*/bin/opkg 2> /dev/null)
-	if [ "$opkgUnknown" ]; then
-		mv "${opkgUnknown%/bin/opkg}" "${opkgUnknown%/entware*/bin/opkg}/entware"
-		logger -t Entware "(Alert) Entware folder ${opkgUnknown%/bin/opkg} renamed to $1/entware"
-		opkgFile=$(/usr/bin/find $1/entware/bin/opkg 2> /dev/null)
-		mount_entware $1
-	else
-		logger -t Entware "(Notice) $1 does not contain Entware, skipping device"
-	fi
+    opkgUnknown=$(/usr/bin/find "$MOUNT_PATH/entware*/bin/opkg" 2> /dev/null)
+    if [ "$opkgUnknown" ]; then
+        mv "${opkgUnknown%/bin/opkg}" "${opkgUnknown%/entware*/bin/opkg}/entware"
+        logger -t Entware "(Alert) Entware folder ${opkgUnknown%/bin/opkg} renamed to $MOUNT_PATH/entware"
+        opkgFile=$(/usr/bin/find "$MOUNT_PATH/entware/bin/opkg" 2> /dev/null)
+        mount_entware
+    else
+        logger -t Entware "(Notice) $MOUNT_PATH does not contain Entware, skipping device"
+    fi
 fi
 #eof


### PR DESCRIPTION
This update introduces a `MOUNT_PATH` variable with a default fallback to enhance flexibility and maintainability of the Entware mount script. It also adds cleanup logic to remove `/tmp/opt` if it’s a broken symlink or directory, ensuring a clean and predictable setup before relinking.

Additionally, quoting and formatting throughout the script were standardized for clarity and consistency.

These changes fixed issues with Entware not starting services properly... at least on my setup. 

Feedback welcome if this breaks or improves things for others! 😉