### PR TITLE
Patch for completeness

### DIFF
--- a/amtm_modules/AdGuardHome.mod
+++ b/amtm_modules/AdGuardHome.mod
@@ -1,5 +1,8 @@
 #!/bin/sh
 #bof
+AdGuardHome_sh(){
+	if sh -c 'sh -c "$(c_url https://raw.githubusercontent.com/jumpsmm7/Asuswrt-Merlin-AdGuardHome-Installer/master/installer)"'; then return 0; else return 1; fi
+}
 AdGuardHome_installed(){
 	scriptname=AdGuardHome
 	scriptgrep='^AI_VERSION'
@@ -67,7 +70,9 @@ AdGuardHome_installed(){
 	[ -z "$updcheck" -a -z "$ss" ] && printf "${GN_BG} ag${NC} %-9s%-21s%${COR}s\\n" "open" "AdGuardHome    $localver" " $upd"
 	[ "$su" = 1 -a -z "$updcheck" ] || [ "$AGHbinUpate" ] && printf "${GN_BG}   ${NC} %-9s%-21s%${COR}s\\n" "" "$AGHext $localAGHver" " $updAGH"
 	case_ag(){
-		/opt/etc/AdGuardHome/installer
+		if ! AdGuardHome_sh; then
+			/opt/etc/AdGuardHome/installer
+		fi
 		sleep 2
 		show_amtm menu
 	}
@@ -80,7 +85,7 @@ install_AdGuardHome(){
 	printf " This installs AdGuardHome - Asuswrt-Merlin-AdGuardHome-Installer\\n on your router.\\n\\n"
 	printf " Author: SomeWhereOverTheRainBow\\n snbforums.com/threads/new-release-asuswrt-merlin-adguardhome-installer.76506/#post-733310\\n"
 	c_d
-	c_url -O https://raw.githubusercontent.com/jumpsmm7/Asuswrt-Merlin-AdGuardHome-Installer/master/installer && sh installer
+	AdGuardHome_sh
 	sleep 2
 	if [ -f /opt/etc/AdGuardHome/installer ]; then
 		show_amtm " AdGuardHome installed"

--- a/amtm_modules/AdGuardHome.mod
+++ b/amtm_modules/AdGuardHome.mod
@@ -70,7 +70,8 @@ AdGuardHome_installed(){
 	[ -z "$updcheck" -a -z "$ss" ] && printf "${GN_BG} ag${NC} %-9s%-21s%${COR}s\\n" "open" "AdGuardHome    $localver" " $upd"
 	[ "$su" = 1 -a -z "$updcheck" ] || [ "$AGHbinUpate" ] && printf "${GN_BG}   ${NC} %-9s%-21s%${COR}s\\n" "" "$AGHext $localAGHver" " $updAGH"
 	case_ag(){
-		if ! AdGuardHome_sh; then
+		if ! AdGuardHome_sh && [ -s "/opt/etc/AdGuardHome/installer" ]; then
+			if [ ! -x "/opt/etc/AdGuardHome/installer" ]; then chmod 0755 /opt/etc/AdGuardHome/installer; fi
 			/opt/etc/AdGuardHome/installer
 		fi
 		sleep 2
@@ -85,11 +86,16 @@ install_AdGuardHome(){
 	printf " This installs AdGuardHome - Asuswrt-Merlin-AdGuardHome-Installer\\n on your router.\\n\\n"
 	printf " Author: SomeWhereOverTheRainBow\\n snbforums.com/threads/new-release-asuswrt-merlin-adguardhome-installer.76506/#post-733310\\n"
 	c_d
-	AdGuardHome_sh
+	if ! AdGuardHome_sh && [ ! -s "/opt/etc/AdGuardHome/installer" ]; then
+		mkdir -p /opt/etc/AdGuardHome /jffs/addons/AdGuardHome.d
+		c_url https://raw.githubusercontent.com/jumpsmm7/Asuswrt-Merlin-AdGuardHome-Installer/master/installer -o /opt/etc/AdGuardHome/installer && chmod 0755 /opt/etc/AdGuardHome/installer
+		/opt/etc/AdGuardHome/installer
+	fi
 	sleep 2
 	if [ -f /opt/etc/AdGuardHome/installer ]; then
 		show_amtm " AdGuardHome installed"
 	else
+		{ rm -rf /opt/etc/AdGuardHome /jffs/addons/AdGuardHome.d; } 2>/dev/null
 		am=;show_amtm " AdGuardHome installation failed"
 	fi
 }

--- a/amtm_modules/AdGuardHome.mod
+++ b/amtm_modules/AdGuardHome.mod
@@ -3,7 +3,7 @@
 AdGuardHome_sh(){
 	local AGH_script
 	AGH_script="$(c_url https://raw.githubusercontent.com/jumpsmm7/Asuswrt-Merlin-AdGuardHome-Installer/master/installer)" || return 1
-	sh -c "$AGH_script"
+	printf "%s\n" "$AGH_script" | sh
 }
 AdGuardHome_installed(){
 	scriptname=AdGuardHome

--- a/amtm_modules/AdGuardHome.mod
+++ b/amtm_modules/AdGuardHome.mod
@@ -1,7 +1,9 @@
 #!/bin/sh
 #bof
 AdGuardHome_sh(){
-	if sh -c 'sh -c "$(c_url https://raw.githubusercontent.com/jumpsmm7/Asuswrt-Merlin-AdGuardHome-Installer/master/installer)"'; then return 0; else return 1; fi
+	local AGH_script
+	AGH_script="$(c_url https://raw.githubusercontent.com/jumpsmm7/Asuswrt-Merlin-AdGuardHome-Installer/master/installer)" || return 1
+	sh -c "$AGH_script"
 }
 AdGuardHome_installed(){
 	scriptname=AdGuardHome

--- a/amtm_modules/dnscrypt.mod
+++ b/amtm_modules/dnscrypt.mod
@@ -68,6 +68,7 @@ dnscrypt_installed(){
 	case_di(){
 		p_e_l
 		if ! dnscrypt_sh && [ -s "/jffs/dnscrypt/installer" ]; then
+			if [ ! -x "/jffs/dnscrypt/installer" ]; then chmod 0755 /jffs/dnscrypt/installer; fi
 			/jffs/dnscrypt/installer
 		fi
 		sleep 5

--- a/amtm_modules/dnscrypt.mod
+++ b/amtm_modules/dnscrypt.mod
@@ -1,7 +1,9 @@
 #!/bin/sh
 #bof
 dnscrypt_sh(){
-	if sh -c 'sh -c "$(c_url https://raw.githubusercontent.com/thuantran/dnscrypt-asuswrt-installer/master/installer)"'; then return 0; else return 1; fi
+	local dnscrypt_script
+	dnscrypt_script="$(c_url https://raw.githubusercontent.com/thuantran/dnscrypt-asuswrt-installer/master/installer)" || return 1
+	sh -c "$dnscrypt_script"
 }
 dnscrypt_installed(){
 	if [ "$su" = 1 ]; then

--- a/amtm_modules/dnscrypt.mod
+++ b/amtm_modules/dnscrypt.mod
@@ -67,7 +67,7 @@ dnscrypt_installed(){
 	[ "$su" = 1 -a -z "$updcheck" ] || [ "$dnscrypt_installerPxUpate" ] && printf "${GN_BG}   ${NC} %-9s%-21s%${COR}s\\n" "" "$dptext $localDPver" " $updDP"
 	case_di(){
 		p_e_l
-		if ! dnscrypt_sh; then
+		if ! dnscrypt_sh && [ -s "/jffs/dnscrypt/installer" ]; then
 			/jffs/dnscrypt/installer
 		fi
 		sleep 5
@@ -91,7 +91,7 @@ install_dnscrypt(){
 	printf " This installs dnscrypt installer\\n on your router.\\n\\n"
 	printf " Authors: bigeyes0x0, SomeWhereOverTheRainBow\\n snbforums.com/forums/asuswrt-merlin-addons.60/?prefix_id=29&starter_id=64179\\n"
 	c_d
-	if ! dnscrypt_sh; then
+	if ! dnscrypt_sh && [ ! -s "/jffs/dnscrypt/installer" ]; then
 		mkdir -p /jffs/dnscrypt
 		c_url https://raw.githubusercontent.com/thuantran/dnscrypt-asuswrt-installer/master/installer -o /jffs/dnscrypt/installer && chmod 0755 /jffs/dnscrypt/installer
 		/jffs/dnscrypt/installer
@@ -100,7 +100,7 @@ install_dnscrypt(){
 	if [ -f /jffs/dnscrypt/manager ]; then
 		show_amtm " dnscrypt installer installed"
 	else
-		rm -rf /jffs/dnscrypt
+		{ rm -rf /jffs/dnscrypt; } 2>/dev/null
 		am=;show_amtm " dnscrypt installer installation failed"
 	fi
 }

--- a/amtm_modules/dnscrypt.mod
+++ b/amtm_modules/dnscrypt.mod
@@ -3,7 +3,7 @@
 dnscrypt_sh(){
 	local dnscrypt_script
 	dnscrypt_script="$(c_url https://raw.githubusercontent.com/thuantran/dnscrypt-asuswrt-installer/master/installer)" || return 1
-	sh -c "$dnscrypt_script"
+	printf "%s\n" "$dnscrypt_script" | sh
 }
 dnscrypt_installed(){
 	if [ "$su" = 1 ]; then

--- a/amtm_modules/dnscrypt.mod
+++ b/amtm_modules/dnscrypt.mod
@@ -1,5 +1,8 @@
 #!/bin/sh
 #bof
+dnscrypt_sh(){
+	if sh -c 'sh -c "$(c_url https://raw.githubusercontent.com/thuantran/dnscrypt-asuswrt-installer/master/installer)"'; then return 0; else return 1; fi
+}
 dnscrypt_installed(){
 	if [ "$su" = 1 ]; then
 		localDPver="$(/jffs/dnscrypt/dnscrypt-proxy -version)"
@@ -64,7 +67,9 @@ dnscrypt_installed(){
 	[ "$su" = 1 -a -z "$updcheck" ] || [ "$dnscrypt_installerPxUpate" ] && printf "${GN_BG}   ${NC} %-9s%-21s%${COR}s\\n" "" "$dptext $localDPver" " $updDP"
 	case_di(){
 		p_e_l
-		/jffs/dnscrypt/installer
+		if ! dnscrypt_sh; then
+			/jffs/dnscrypt/installer
+		fi
 		sleep 5
 		show_amtm menu
 	}
@@ -86,9 +91,11 @@ install_dnscrypt(){
 	printf " This installs dnscrypt installer\\n on your router.\\n\\n"
 	printf " Authors: bigeyes0x0, SomeWhereOverTheRainBow\\n snbforums.com/forums/asuswrt-merlin-addons.60/?prefix_id=29&starter_id=64179\\n"
 	c_d
-	mkdir -p /jffs/dnscrypt
-	c_url https://raw.githubusercontent.com/thuantran/dnscrypt-asuswrt-installer/master/installer -o /jffs/dnscrypt/installer && chmod 0755 /jffs/dnscrypt/installer
-	/jffs/dnscrypt/installer
+	if ! dnscrypt_sh; then
+		mkdir -p /jffs/dnscrypt
+		c_url https://raw.githubusercontent.com/thuantran/dnscrypt-asuswrt-installer/master/installer -o /jffs/dnscrypt/installer && chmod 0755 /jffs/dnscrypt/installer
+		/jffs/dnscrypt/installer
+	fi
 	sleep 2
 	if [ -f /jffs/dnscrypt/manager ]; then
 		show_amtm " dnscrypt installer installed"


### PR DESCRIPTION
A lot of users lately have had a complaint in either AMTM or to the script dev itself on how AMTM perceives and utilizes the installers for these binaries. This should resolve that issue and provide completeness for the module files for Adguardhome and dnscrypt-proxy. The way these installers were written makes it almost impossible to update the installer without downloading a fresh installer first. Especially when the older installer had bugs in the code, or something changed in the API ratelimits. 