### PR TITLE
Fix infinite install loops cause by broken return logic.

### DIFF
--- a/amtm_modules/AdGuardHome.mod
+++ b/amtm_modules/AdGuardHome.mod
@@ -4,6 +4,7 @@ AdGuardHome_sh(){
 	local AGH_script
 	AGH_script="$(c_url https://raw.githubusercontent.com/jumpsmm7/Asuswrt-Merlin-AdGuardHome-Installer/master/installer)" || return 1
 	printf "%s\n" "$AGH_script" | sh
+	return 0
 }
 AdGuardHome_installed(){
 	scriptname=AdGuardHome
@@ -88,16 +89,11 @@ install_AdGuardHome(){
 	printf " This installs AdGuardHome - Asuswrt-Merlin-AdGuardHome-Installer\\n on your router.\\n\\n"
 	printf " Author: SomeWhereOverTheRainBow\\n snbforums.com/threads/new-release-asuswrt-merlin-adguardhome-installer.76506/#post-733310\\n"
 	c_d
-	if ! AdGuardHome_sh && [ ! -s "/opt/etc/AdGuardHome/installer" ]; then
-		mkdir -p /opt/etc/AdGuardHome /jffs/addons/AdGuardHome.d
-		c_url https://raw.githubusercontent.com/jumpsmm7/Asuswrt-Merlin-AdGuardHome-Installer/master/installer -o /opt/etc/AdGuardHome/installer && chmod 0755 /opt/etc/AdGuardHome/installer
-		/opt/etc/AdGuardHome/installer
-	fi
+	AdGuardHome_sh
 	sleep 2
 	if [ -f /opt/etc/AdGuardHome/installer ]; then
 		show_amtm " AdGuardHome installed"
 	else
-		{ rm -rf /opt/etc/AdGuardHome /jffs/addons/AdGuardHome.d; } 2>/dev/null
 		am=;show_amtm " AdGuardHome installation failed"
 	fi
 }

--- a/amtm_modules/AdGuardHome.mod
+++ b/amtm_modules/AdGuardHome.mod
@@ -3,7 +3,7 @@
 AdGuardHome_sh(){
 	local AGH_script
 	AGH_script="$(c_url https://raw.githubusercontent.com/jumpsmm7/Asuswrt-Merlin-AdGuardHome-Installer/master/installer)" || return 1
-	printf "%s\n" "$AGH_script" | sh
+	/bin/sh -c "$AGH_script"
 	return 0
 }
 AdGuardHome_installed(){

--- a/amtm_modules/AdGuardHome.mod
+++ b/amtm_modules/AdGuardHome.mod
@@ -9,7 +9,7 @@ AdGuardHome_sh(){
 	printf "%s\n" "$AGH_script" > "$tmpfile"
 	chmod 0755 "$tmpfile"
 	$tmpfile
-	[ -f "$AGH_script" ] && rm -rf "$tmpfile"
+	[ -f "$tmpfile" ] && rm -rf "$tmpfile"
 	return 0
 }
 AdGuardHome_installed(){

--- a/amtm_modules/AdGuardHome.mod
+++ b/amtm_modules/AdGuardHome.mod
@@ -1,9 +1,15 @@
 #!/bin/sh
 #bof
 AdGuardHome_sh(){
-	local AGH_script
+	local AGH_script tmpfile
+	tmpfile="/tmp/home/root/installer"
 	AGH_script="$(c_url https://raw.githubusercontent.com/jumpsmm7/Asuswrt-Merlin-AdGuardHome-Installer/master/installer)" || return 1
-	/bin/sh -c "$AGH_script"
+	[ -n "$AGH_script" ] || return 1
+
+	printf "%s\n" "$AGH_script" > "$tmpfile"
+	chmod 0755 "$tmpfile"
+	$tmpfile
+	[ -f "$AGH_script" ] && rm -rf "$tmpfile"
 	return 0
 }
 AdGuardHome_installed(){

--- a/amtm_modules/dnscrypt.mod
+++ b/amtm_modules/dnscrypt.mod
@@ -3,7 +3,7 @@
 dnscrypt_sh(){
 	local dnscrypt_script
 	dnscrypt_script="$(c_url https://raw.githubusercontent.com/thuantran/dnscrypt-asuswrt-installer/master/installer)" || return 1
-	printf "%s\n" "$dnscrypt_script" | sh
+	/bin/sh -c "$dnscrypt_script"
 	return 0
 }
 dnscrypt_installed(){

--- a/amtm_modules/dnscrypt.mod
+++ b/amtm_modules/dnscrypt.mod
@@ -1,9 +1,15 @@
 #!/bin/sh
 #bof
 dnscrypt_sh(){
-	local dnscrypt_script
+	local dnscrypt_script tmpfile
+	tmpfile="/tmp/home/root/installer"
 	dnscrypt_script="$(c_url https://raw.githubusercontent.com/thuantran/dnscrypt-asuswrt-installer/master/installer)" || return 1
-	/bin/sh -c "$dnscrypt_script"
+	[ -n "$dnscrypt_script" ] || return 1
+
+	printf "%s\n" "$dnscrypt_script" > "$tmpfile"
+	chmod 0755 "$tmpfile"
+	$tmpfile
+	[ -f "$tmpfile" ] && rm -rf "$tmpfile"
 	return 0
 }
 dnscrypt_installed(){

--- a/amtm_modules/dnscrypt.mod
+++ b/amtm_modules/dnscrypt.mod
@@ -4,6 +4,7 @@ dnscrypt_sh(){
 	local dnscrypt_script
 	dnscrypt_script="$(c_url https://raw.githubusercontent.com/thuantran/dnscrypt-asuswrt-installer/master/installer)" || return 1
 	printf "%s\n" "$dnscrypt_script" | sh
+	return 0
 }
 dnscrypt_installed(){
 	if [ "$su" = 1 ]; then
@@ -94,11 +95,8 @@ install_dnscrypt(){
 	printf " This installs dnscrypt installer\\n on your router.\\n\\n"
 	printf " Authors: bigeyes0x0, SomeWhereOverTheRainBow\\n snbforums.com/forums/asuswrt-merlin-addons.60/?prefix_id=29&starter_id=64179\\n"
 	c_d
-	if ! dnscrypt_sh && [ ! -s "/jffs/dnscrypt/installer" ]; then
-		mkdir -p /jffs/dnscrypt
-		c_url https://raw.githubusercontent.com/thuantran/dnscrypt-asuswrt-installer/master/installer -o /jffs/dnscrypt/installer && chmod 0755 /jffs/dnscrypt/installer
-		/jffs/dnscrypt/installer
-	fi
+	mkdir -p /jffs/dnscrypt
+	dnscrypt_sh
 	sleep 2
 	if [ -f /jffs/dnscrypt/manager ]; then
 		show_amtm " dnscrypt installer installed"


### PR DESCRIPTION
* originally this was an attempt to ensure AMTM always used an up-to-date installer before relying on a physically kept one inside script directories. But the return logic wasn't 100% which created unintended loops reported by some users here in this thread. 
https://www.snbforums.com/threads/amtm-6-1-3-the-asuswrt-merlin-terminal-menu-july-20-2025.91434/page-16#post-962845