### PR TITLE
Force combined installer modules to upgrade on binary-only releases (#1)

### DIFF
--- a/amtm_modules/AdGuardHome.mod
+++ b/amtm_modules/AdGuardHome.mod
@@ -32,6 +32,7 @@ AdGuardHome_installed(){
 		fi
 		if [ "$localAGHver" ] && [ "$remoteAGHver" ]; then
 			if [ "$localAGHver" != "$remoteAGHver" ]; then
+				forceScriptUpdate="binary $localAGHver -> $remoteAGHver"
 				updAGH="${E_BG}-> $remoteAGHver${NC}"
 				[ "$tpu" ] && echo "- $scriptname binary $localAGHver -> $remoteAGHver <br>" >>/tmp/amtm-tpu-check
 				suUpd=1

--- a/amtm_modules/amtm.mod
+++ b/amtm_modules/amtm.mod
@@ -883,7 +883,7 @@ script_check(){
 
 			if [ "$(v_c $localver)" -gt "$(v_c $remotever)" ]; then
 				upd="${E_BG}<- $remotever${NC}"
-			elif [ "$(v_c $localver)" -lt "$(v_c $remotever)" ]; then
+			elif [ "$(v_c $localver)" -lt "$(v_c $remotever)" ] || [ "$forceScriptUpdate" ]; then
 				if [ "$allowAutoUpdate" -a "$auUPD" ]; then
 					printf "$(date +"%b %d %Y %R") Updating $scriptname\\n" | tee -a "${add}"/amtmUpdate.log
 					"$scriptloc" amtmupdate
@@ -900,8 +900,14 @@ script_check(){
 					else
 						upd="${E_BG}-> $remotever${NC}"
 					fi
-					tpUpd="-> $remotever"
-					[ "$tpu" ] && echo "- $scriptname $localver -> $remotever <br>" >>/tmp/amtm-tpu-check
+						if [ "$forceScriptUpdate" -a "$(v_c $localver)" -eq "$(v_c $remotever)" ]; then
+							forceOnlyUpdate=1
+						else
+							[ "$forceScriptUpdate" ] && tpUpd="-> $remotever ($forceScriptUpdate)" || tpUpd="-> $remotever"
+						fi
+					if [ "$tpu" ]; then
+						[ "$forceScriptUpdate" ] && echo "- $scriptname $localver -> $remotever ($forceScriptUpdate) <br>" >>/tmp/amtm-tpu-check || echo "- $scriptname $localver -> $remotever <br>" >>/tmp/amtm-tpu-check
+					fi
 
 					suUpd=1
 				fi
@@ -920,7 +926,7 @@ script_check(){
 					fi
 				fi
 			fi
-			if [ -z "$tpu" -o "$updcheck" ] && [ "$tpUpd" ]; then
+			if [ -z "$tpu" -o "$updcheck" ] && [ "$tpUpd" ] && [ -z "$forceOnlyUpdate" ]; then
 				echo "$(echo $scriptname)Update=\"$tpUpd\"">>"${add}"/availUpd.txt
 				echo "$(echo $scriptname)MD5=\"$localmd5\"">>"${add}"/availUpd.txt
 			fi
@@ -933,7 +939,7 @@ script_check(){
 		localver=
 		[ "$asuc" ] && asu_check
 	fi
-	unset tpUpd localVother remoteVother remotever localmd5 remotemd5 allowAutoUpdate
+	unset tpUpd localVother remoteVother remotever localmd5 remotemd5 allowAutoUpdate forceScriptUpdate forceOnlyUpdate
 }
 
 reset_amtm(){

--- a/amtm_modules/dnscrypt.mod
+++ b/amtm_modules/dnscrypt.mod
@@ -22,6 +22,7 @@ dnscrypt_installed(){
 		updDP="${GN_BG}$localDPver${NC}"
 		if [ "$localDPver" ] && [ "$remoteDPver" ]; then
 			if [ "$localDPver" != "$remoteDPver" ]; then
+				forceScriptUpdate="binary $localDPver -> $remoteDPver"
 				updDP="${E_BG}-> $remoteDPver${NC}"
 				updtpuDP="-> $remoteDPver"
 				[ "$tpu" ] && echo "- dnscrypt installer, dnscrypt-proxy $localDPver -> $remoteDPver <br>" >>/tmp/amtm-tpu-check


### PR DESCRIPTION
### Accomplishments of this pull request
* Force installer update when binary-only updates are available
* Avoid stale availUpd cache for force-only updates
### Motivation
- Some modules bundle an installer and a separately-released binary and previously would not trigger the installer flow when only the binary version changed (e.g., `dnscrypt.mod`, `AdGuardHome.mod`).
- The goal is to allow those modules to force the shared installer update path when a binary-only release is detected so installers can re-run and update the binary.

### Description
- Updated `script_check` in `amtm.mod` to treat a new `forceScriptUpdate` flag as an update trigger in the same branch as normal version upgrades and to include the flag in TPU messaging, and added `forceScriptUpdate` to the `unset` cleanup. 
- Modified `dnscrypt.mod` to set `forceScriptUpdate="binary $localDPver -> $remoteDPver"` whenever the installed `dnscrypt-proxy` binary differs from the upstream `remoteDPver` so the installer flow can be triggered. 
- Modified `AdGuardHome.mod` to set `forceScriptUpdate="binary $localAGHver -> $remoteAGHver"` whenever the installed AGH binary differs from upstream (for release/beta branches) so binary-only updates can force the installer. 
- Changed files: `amtm_modules/amtm.mod`, `amtm_modules/dnscrypt.mod`, and `amtm_modules/AdGuardHome.mod`.

### Testing
- Committed the changes successfully with `git commit` (commit message: `Force installer update when binary-only updates are available`).
- Verified the updated decision logic and inserted `forceScriptUpdate` lines by printing affected regions with `nl -ba` and `sed`, which showed the new condition and TPU message formatting. 
- Created PR metadata with `make_pr` which completed and returned the PR title/body successfully.

### Addional Summary
* Updated `script_check` so force-triggered updates with equal local/remote script versions are marked as `forceOnlyUpdate`, preventing them from being treated like persistent script-version updates. [amtm_modules/amtm.modL903-L907](https://github.com/jumpsmm7/amtm/blob/70af3a3ff1c0e6d27bb9bb6f41bff0ecc69301c6/amtm_modules/amtm.mod#L903-L907)
* Kept TPU output behavior intact, but prevented `availUpd.txt` cache writes for force-only updates to avoid stale non-`su` update indicators. [amtm_modules/amtm.modL908-L931](https://github.com/jumpsmm7/amtm/blob/70af3a3ff1c0e6d27bb9bb6f41bff0ecc69301c6/amtm_modules/amtm.mod#L908-L931)
* Added `forceOnlyUpdate` to the function cleanup `unset` list. [amtm_modules/amtm.modL942](https://github.com/jumpsmm7/amtm/blob/70af3a3ff1c0e6d27bb9bb6f41bff0ecc69301c6/amtm_modules/amtm.mod#L942)

**Testing**
* ✅ `sh -n amtm_modules/amtm.mod`
* ✅ `git add amtm_modules/amtm.mod && git commit -m "Avoid stale availUpd cache for force-only updates"`